### PR TITLE
Four global variables

### DIFF
--- a/src/GUI/main.py
+++ b/src/GUI/main.py
@@ -16,10 +16,11 @@ from PyQt6.QtWidgets import QDialog, QApplication, QMainWindow, QFileDialog
 import SimpleITK as sitk
 from src.utils.mri_image import MRIImage, MRIImageList
 from src.utils.imgproc_helpers import *
+import src.utils.globs as globs
 
-DEFAULT_WIDTH: int = 900
+DEFAULT_WIDTH: int = 1000
 """Startup width of the GUI"""
-DEFAULT_HEIGHT: int = 600
+DEFAULT_HEIGHT: int = 700
 """Startup height of the GUI"""
 
 # Since QPixmap doesn't support rendering from a sitk.Image or np.ndarray, must save images as jpg/png
@@ -28,7 +29,7 @@ IMG_DIR: pathlib.Path = pathlib.Path('.') / 'img'
 """Directory used to save f'{i}.{IMAGE_EXTENSION}' files corresponding to the currently open images, where `i` is the index (zero-indexed) of the image.
 
 Files will need to be renamed during Add Image or Delete Image operations."""
-IMAGE_EXTENSION: str = 'png'
+IMAGE_EXTENSION: str = 'jpg'
 """Extension for images stored in `IMG_DIR`."""
 
 NRRD0_PATH: pathlib.Path = pathlib.Path('ExampleData/BCP_Dataset_2month_T1w.nrrd')
@@ -38,11 +39,6 @@ NIFTI_PATH: pathlib.Path = pathlib.Path('ExampleData/MicroBiome_1month_T1w.nii.g
 
 MAIN_WINDOW_INDEX = 0
 CIRCUMFERENCE_WINDOW_INDEX = 1
-
-# To share this between the 2 classes, unfortunately need to type global IMAGE_LIST inside every function that uses it :(
-# TODO: Is there a way to get around this?
-IMAGE_LIST: MRIImageList = MRIImageList()
-"""Global variable within this file (2 classes)."""
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -68,12 +64,14 @@ class MainWindow(QMainWindow):
         The return value of `getOpenFileNames` is a tuple `(list[str], str)`, where the left element is a list of paths.
         
         So `fnames[0][i]` is the i'th path selected."""
-        global IMAGE_LIST
         # TODO: Let starting directory be a configurable setting in JSON
         files = QFileDialog.getOpenFileNames(self, 'Open file(s)', str(pathlib.Path.cwd()), 'MRI images (*.nii.gz *.nii *.nrrd)')
         paths = map(pathlib.Path, files[0])
         images = list(map(MRIImage, paths))
-        IMAGE_LIST = MRIImageList(images)
+        globs.IMAGE_LIST = MRIImageList(images)
+        globs.CURR_MRI_IMAGE = globs.IMAGE_LIST.get_curr_mri_image()
+        globs.CURR_SLICE = globs.CURR_MRI_IMAGE.get_rotated_slice()
+        globs.CURR_SLICE_INDEX = globs.IMAGE_LIST.get_index()
         self.enable_elements()
         self.save_all_slices_to_img_dir()
         self.render_curr_image_from_img_dir()
@@ -84,13 +82,11 @@ class MainWindow(QMainWindow):
         """Switch to CircumferenceWindow.
         
         Compute circumference and update slice settings."""
-        global IMAGE_LIST
-        curr_image: MRIImage = IMAGE_LIST.get_curr_mri_image()
         widget.setCurrentIndex(CIRCUMFERENCE_WINDOW_INDEX)
         circumference_window.render_curr_image_from_img_dir()
-        circumference: float = get_contour_length(process_slice_and_get_contour(curr_image.get_rotated_slice()))
+        circumference: float = get_contour_length(process_slice_and_get_contour(globs.CURR_SLICE))
         circumference_window.circumference_label.setText(f'Circumference: {circumference}')
-        circumference_window.slice_settings_text.setText(f'X rotation: {curr_image.get_theta_x()}°\nY rotation: {curr_image.get_theta_y()}°\nZ rotation: {curr_image.get_theta_z()}°\nSlice: {curr_image.get_slice_z()}')
+        circumference_window.slice_settings_text.setText(f'X rotation: {globs.CURR_MRI_IMAGE.get_theta_x()}°\nY rotation: {globs.CURR_MRI_IMAGE.get_theta_y()}°\nZ rotation: {globs.CURR_MRI_IMAGE.get_theta_z()}°\nSlice: {globs.CURR_MRI_IMAGE.get_slice_z()}')
 
     
     def enable_elements(self):
@@ -111,50 +107,43 @@ class MainWindow(QMainWindow):
         """Only called after `Open` is pressed. Saves all `rotated_slice`s in `IMAGE_LIST` to `./img/` to ensure that all can be rendered.
         
         Each `MRIImage` gets a `rotated_slice` field during initialization with rotation and slice values all 0, which allows this to work."""
-        global IMAGE_LIST
-        for (i, mri_image) in enumerate(IMAGE_LIST):
+        for (i, mri_image) in enumerate(globs.IMAGE_LIST):
             save_sitk_slice_to_file(mri_image.get_rotated_slice(), IMG_DIR / f'{i}.{IMAGE_EXTENSION}')
 
     
     def save_curr_slice_to_img_dir(self):
         """Save the current slice to `IMG_DIR`."""
-        global IMAGE_LIST
-        curr_index: int = IMAGE_LIST.get_index()
-        # This isn't a syntax error at runtime.
-        # MRIImageList's __getitem__ implementation can't specify that it can return MRIImage or MRIImageList
-        save_sitk_slice_to_file(IMAGE_LIST[curr_index].get_rotated_slice(), IMG_DIR / f'{curr_index}.{IMAGE_EXTENSION}')
+        save_sitk_slice_to_file(globs.CURR_SLICE, IMG_DIR / f'{globs.CURR_SLICE_INDEX}.{IMAGE_EXTENSION}')
 
 
     def render_curr_image_from_img_dir(self):
-        """Render the current image from stored file (i.e., no resampling).
+        """Same as `CircumferenceWindow.render_curr_image_from_img_dir`.
+        
+        Render the current image from stored file (i.e., no resampling).
         
         Call only if `MRIImage.rotated_slice` at `image_list.index` has already been stored to `IMG_DIR`.
         
         Also sets text for `image_num_label` and file path in the status bar tooltip."""
-        global IMAGE_LIST
-        curr_index: int = IMAGE_LIST.get_index()
-        filepath = IMG_DIR / f'{curr_index}.{IMAGE_EXTENSION}'
+        filepath = IMG_DIR / f'{globs.CURR_SLICE_INDEX}.{IMAGE_EXTENSION}'
         self.image.setPixmap(QtGui.QPixmap(str(filepath)))
         # No zero indexing when displaying to user
-        self.image_num_label.setText(f'Image {curr_index + 1} of {len(IMAGE_LIST)}')
+        self.image_num_label.setText(f'Image {globs.CURR_SLICE_INDEX + 1} of {len(globs.IMAGE_LIST)}')
         # TODO: Can probably truncate the path
-        self.image.setStatusTip(str(IMAGE_LIST.get_curr_mri_image().get_path()))
+        self.image.setStatusTip(str(globs.CURR_MRI_IMAGE.get_path()))
 
     
     def render_all_sliders(self):
-        """Sets all slider values to the correct values (the values stored in the `MRIImage`).
+        """Sets all slider values to the values stored in the `MRIImage`.
         
         Also updates rotation and slice num values."""
-        global IMAGE_LIST
-        curr_slice: MRIImage = IMAGE_LIST.get_curr_mri_image()
-        theta_x = curr_slice.get_theta_x()
-        theta_y = curr_slice.get_theta_y()
-        theta_z = curr_slice.get_theta_z()
-        slice_num = curr_slice.get_slice_z()
+        theta_x = globs.CURR_MRI_IMAGE.get_theta_x()
+        theta_y = globs.CURR_MRI_IMAGE.get_theta_y()
+        theta_z = globs.CURR_MRI_IMAGE.get_theta_z()
+        slice_num = globs.CURR_MRI_IMAGE.get_slice_z()
         self.x_slider.setValue(theta_x)
         self.y_slider.setValue(theta_y)
         self.z_slider.setValue(theta_z)
-        self.slice_slider.setMaximum(curr_slice.get_dimensions()[2] - 1)
+        self.slice_slider.setMaximum(globs.CURR_MRI_IMAGE.get_dimensions()[2] - 1)
         self.slice_slider.setValue(slice_num)
         self.x_rotation_label.setText(f'X rotation: {theta_x}°')
         self.y_rotation_label.setText(f'Y rotation: {theta_y}°')
@@ -162,90 +151,86 @@ class MainWindow(QMainWindow):
         self.slice_num_label.setText(f'Slice: {slice_num}')
 
 
+    """
+    Careful with setter methods below! Updating IMAGE_LIST won't automatically update CURR_MRI_IMAGE or CURR_SLICE or CURR_SLICE_INDEX since the variables are separate.
+    TODO: Determine whether to remove all global vars except IMAGE_LIST for code safety.
+    Or can update globals within the mri_image.py class?
+    """
+
+
     def next_img(self):
         """Advance index and render."""
-        global IMAGE_LIST
-        IMAGE_LIST.next()
+        globs.IMAGE_LIST.next()
+        globs.CURR_MRI_IMAGE = globs.IMAGE_LIST.get_curr_mri_image()
+        globs.CURR_SLICE = globs.CURR_MRI_IMAGE.get_rotated_slice()
+        globs.CURR_SLICE_INDEX = globs.IMAGE_LIST.get_index()
         self.render_curr_image_from_img_dir()
         self.render_all_sliders()
 
 
     def previous_img(self):
         """Decrement index and render."""
-        global IMAGE_LIST
-        IMAGE_LIST.previous()
+        globs.IMAGE_LIST.previous()
+        globs.CURR_MRI_IMAGE = globs.IMAGE_LIST.get_curr_mri_image()
+        globs.CURR_SLICE = globs.CURR_MRI_IMAGE.get_rotated_slice()
+        globs.CURR_SLICE_INDEX = globs.IMAGE_LIST.get_index()
         self.render_curr_image_from_img_dir()
         self.render_all_sliders()
 
     
     def rotate_x(self):
         """Handle x slider movement."""
-        global IMAGE_LIST
-        curr_image: MRIImage = IMAGE_LIST.get_curr_mri_image()
         x_slider_val: int = self.x_slider.value()
-        curr_image.set_theta_x(x_slider_val)
-        curr_image.resample()
-        # This method recomputes the current slice. Unnecessary work.
+        globs.CURR_MRI_IMAGE.set_theta_x(x_slider_val)
+        globs.CURR_MRI_IMAGE.resample()
+        globs.CURR_SLICE = globs.CURR_MRI_IMAGE.get_rotated_slice()
         self.save_curr_slice_to_img_dir()
-        # Same here
         self.render_curr_image_from_img_dir()
         self.x_rotation_label.setText(f'X rotation: {x_slider_val}°')
 
 
     def rotate_y(self):
         """Handle y slider movement."""
-        global IMAGE_LIST
-        curr_image: MRIImage = IMAGE_LIST.get_curr_mri_image()
         y_slider_val: int = self.y_slider.value()
-        curr_image.set_theta_y(y_slider_val)
-        curr_image.resample()
-        # This method recomputes the current slice. Unnecessary work.
+        globs.CURR_MRI_IMAGE.set_theta_y(y_slider_val)
+        globs.CURR_MRI_IMAGE.resample()
+        globs.CURR_SLICE = globs.CURR_MRI_IMAGE.get_rotated_slice()
         self.save_curr_slice_to_img_dir()
-        # Same here
         self.render_curr_image_from_img_dir()
         self.y_rotation_label.setText(f'Y rotation: {y_slider_val}°')
 
 
     def rotate_z(self):
         """Handle z slider movement."""
-        global IMAGE_LIST
-        curr_image: MRIImage = IMAGE_LIST.get_curr_mri_image()
         z_slider_val: int = self.z_slider.value()
-        curr_image.set_theta_z(z_slider_val)
-        curr_image.resample()
-        # This method recomputes the current slice. Unnecessary work.
+        globs.CURR_MRI_IMAGE.set_theta_z(z_slider_val)
+        globs.CURR_MRI_IMAGE.resample()
+        globs.CURR_SLICE = globs.CURR_MRI_IMAGE.get_rotated_slice()
         self.save_curr_slice_to_img_dir()
-        # Same here
         self.render_curr_image_from_img_dir()
         self.z_rotation_label.setText(f'Z rotation: {z_slider_val}°')
 
 
     def slice_update(self):
         """Handle slice slider movement."""
-        global IMAGE_LIST
-        curr_image: MRIImage = IMAGE_LIST.get_curr_mri_image()
         slice_slider_val: int = self.slice_slider.value()
-        curr_image.set_slice_z(slice_slider_val)
-        curr_image.resample()
-        # This method recomputes the current slice. Unnecessary work.
+        globs.CURR_MRI_IMAGE.set_slice_z(slice_slider_val)
+        globs.CURR_MRI_IMAGE.resample()
+        globs.CURR_SLICE = globs.CURR_MRI_IMAGE.get_rotated_slice()
         self.save_curr_slice_to_img_dir()
-        # Same here
         self.render_curr_image_from_img_dir()
         self.slice_num_label.setText(f'Slice: {slice_slider_val}')
 
 
     def reset_settings(self):
         """Reset rotation values and slice num to 0 for the current image."""
-        global IMAGE_LIST
-        curr_image: MRIImage = IMAGE_LIST.get_curr_mri_image()
-        curr_image.set_theta_x(0)
-        curr_image.set_theta_y(0)
-        curr_image.set_theta_z(0)
-        curr_image.set_slice_z(0)
-        curr_image.resample()
-        # This method recomputes the current slice. Unnecessary work.
+        globs.CURR_MRI_IMAGE.set_theta_x(0)
+        globs.CURR_MRI_IMAGE.set_theta_y(0)
+        globs.CURR_MRI_IMAGE.set_theta_z(0)
+        globs.CURR_MRI_IMAGE.set_slice_z(0)
+        globs.CURR_MRI_IMAGE.resample()
+        globs.CURR_SLICE = globs.CURR_MRI_IMAGE.get_rotated_slice()
         self.save_curr_slice_to_img_dir()
-        # Same here
         self.render_curr_image_from_img_dir()
         self.render_all_sliders()
 
@@ -260,24 +245,26 @@ class CircumferenceWindow(QMainWindow):
 
     
     def goto_main(self):
-        """Switch to MainWindow."""
+        """Switch to MainWindow.
+        
+        Image and sliders aren't modified in `CircumferenceWindow` so no need to re-render anything."""
         widget.setCurrentIndex(MAIN_WINDOW_INDEX)
 
 
     def render_curr_image_from_img_dir(self):
-        """Render the current image from stored file (i.e., no resampling).
+        """Same as `MainWindow.render_curr_image_from_img_dir`.
+        
+        Render the current image from stored file (i.e., no resampling).
         
         Call only if `MRIImage.rotated_slice` at `image_list.index` has already been stored to `IMG_DIR`.
         
         Also sets text for `image_num_label` and file path in the status bar tooltip."""
-        global IMAGE_LIST
-        curr_index: int = IMAGE_LIST.get_index()
-        filepath = IMG_DIR / f'{curr_index}.{IMAGE_EXTENSION}'
+        filepath = IMG_DIR / f'{globs.CURR_SLICE_INDEX}.{IMAGE_EXTENSION}'
         self.image.setPixmap(QtGui.QPixmap(str(filepath)))
         # No zero indexing when displaying to user
-        self.image_num_label.setText(f'Image {curr_index +1 } of {len(IMAGE_LIST)}')
+        self.image_num_label.setText(f'Image {globs.CURR_SLICE_INDEX + 1} of {len(globs.IMAGE_LIST)}')
         # TODO: Can probably truncate the path
-        self.image.setStatusTip(str(IMAGE_LIST.get_curr_mri_image().get_path()))
+        self.image.setStatusTip(str(globs.CURR_MRI_IMAGE.get_path()))
 
 
 def main() -> None:

--- a/src/utils/globs.py
+++ b/src/utils/globs.py
@@ -1,0 +1,27 @@
+"""Global variables"""
+
+import SimpleITK as sitk
+from src.utils.mri_image import MRIImage, MRIImageList
+
+# These might not be needed
+# global IMAGE_LIST
+# global CURR_MRI_IMAGE
+# global CURR_SLICE
+# global CURR_SLICE_INDEX
+
+IMAGE_LIST: MRIImageList = MRIImageList()
+CURR_MRI_IMAGE: MRIImage
+"""`IMAGE_LIST`'s current `MRIImage`.
+
+Warning: Not automatically updated when calling `IMAGE_LIST.next()` or `.previous()`. Must manually adjust."""
+# TODO: Could remove this variable since you have to remember to update it after updating CURR_MRI_IMAGE
+# Only a minor convenience but could cause serious bugs
+CURR_SLICE: sitk.Image = sitk.Image(8, 8, 0, sitk.sitkUInt8)
+"""`IMAGE_LIST`'s current rotated slice.
+
+Warning: Not automatically updated when calling `CURR_MRI_IMAGE`.resample()` or `IMAGE_LIST.next()` or `.previous()`. Must manually update this after resampling."""
+# Same with this variable
+CURR_SLICE_INDEX: int = 0
+"""`IMAGE_LIST`'s current `index`.
+
+Warning: Not automatically updated when calling `IMAGE_LIST.next()` or `.previous()`. Must manually update after doing so."""

--- a/src/utils/imgproc_helpers.py
+++ b/src/utils/imgproc_helpers.py
@@ -16,6 +16,7 @@ except ModuleNotFoundError:
     # This is for processing.ipynb
     import exceptions
 from src.utils.mri_image import MRIImage, MRIImageList
+import src.utils.globs as globs
 
 
 # Source: https://stackoverflow.com/questions/2536307/decorators-in-the-python-standard-lib-deprecated-specifically

--- a/src/utils/mri_image.py
+++ b/src/utils/mri_image.py
@@ -180,6 +180,9 @@ class MRIImage:
 
 # Credit: https://github.com/python/cpython/blob/208a7e957b812ad3b3733791845447677a704f3e/Lib/collections/__init__.py#L1174
 class MRIImageList(_collections_abc.MutableSequence):
+    """There should only be a single instance of `MRIImageList`. It modifies global variables.
+    
+    Not enforced, but don't make more than one instance."""
     # Commented out because this syntax doesn't work on older versions of Python
     # images: list[MRIImage]
     index: int = 0


### PR DESCRIPTION
`IMAGE_LIST`, `CURR_MRI_IMAGE`, `CURR_SLICE`, `CURR_SLICE_INDEX`

The code works fine but is not very friendly for us and future maintainers.

The problem with these 4 global variables is that IMAGE_LIST.next() doesn't automatically modify CURR_MRI_IMAGE, CURR_SLICE, and CURR_SLICE_INDEX, so they have to be adjusted manually. This will likely cause bugs.

However, we do want these global variables for convenience. See src/GUI/main.py. There'd be a lot of repeated boilerplate code in each method without those globals.

Option 2: Have only one global variable IMAGE_LIST, which will result in more boilerplate but will be safe.

Option 3 (pushing to main soon): In mri_image.py, MRIImageList's next() and previous() methods will modify all 4 global variables. This assumes there will only ever be a single instance of MRIImageList.

Similarly, MRIImage's resample() method will update CURR_SLICE.