### PR TITLE
Jpg vs np

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ include/
 share/
 pyvenv.cfg
 src/GUI/np_array_slice.txt
+test.txt

--- a/Playground/imgproc/imgproc_helpers.py
+++ b/Playground/imgproc/imgproc_helpers.py
@@ -14,21 +14,8 @@ except ModuleNotFoundError:
     # This is for processing.ipynb
     import exceptions
 
+from src.utils.globs import deprecated
 
-# Source: https://stackoverflow.com/questions/2536307/decorators-in-the-python-standard-lib-deprecated-specifically
-def deprecated(func):
-    """This is a decorator which can be used to mark functions
-    as deprecated. It will result in a warning being emitted
-    when the function is used."""
-    @functools.wraps(func)
-    def new_func(*args, **kwargs):
-        warnings.simplefilter('always', DeprecationWarning)  # turn off filter
-        warnings.warn("Call to deprecated function {}.".format(func.__name__),
-                      category=DeprecationWarning,
-                      stacklevel=2)
-        warnings.simplefilter('default', DeprecationWarning)  # reset filter
-        return func(*args, **kwargs)
-    return new_func
 
 
 def rotate_and_get_contour(img: sitk.Image, theta_x: int, theta_y: int, theta_z: int, slice_z: int) -> sitk.Image:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ opencv-python==4.7.0.72
 pytest==6.2.5
 autopep8==2.0.2
 PyQt6==6.4.2
+multipledispatch==0.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,4 @@ ipywidgets==7.7.0
 argparse==1.4.0
 opencv-python==4.7.0.72
 PyQt6==6.4.2
+multipledispatch==0.6.0

--- a/src/GUI/main.py
+++ b/src/GUI/main.py
@@ -81,9 +81,11 @@ class MainWindow(QMainWindow):
         Compute circumference and update slice settings."""
         curr_mri_image: MRIImage = globs.IMAGE_LIST.get_curr_mri_image()
         widget.setCurrentIndex(CIRCUMFERENCE_WINDOW_INDEX)
-        # circumference_window.render_curr_slice()
 
-        circumference_window.render_curr_slice_from_img_dir()
+        if USE_JPG:
+            circumference_window.render_curr_slice_from_img_dir()
+        else:
+            circumference_window.render_curr_slice()
 
         circumference: float = imgproc.get_contour_length(
             imgproc.get_contour(curr_mri_image.get_rotated_slice()))

--- a/src/utils/exceptions.py
+++ b/src/utils/exceptions.py
@@ -35,3 +35,13 @@ class RemoveAtInvalidIndex(Exception):
     def __init__(self, index: int):
         self.message = f'You attempted to remove an image at index {index + 1}, which doesn\'t exist in the list of images.'
         super().__init__(self.message)
+
+class RangeTooSmallForAccurateFlooredResult(Exception):
+    def __init__(self, old_range, new_range):
+        self.message = f'Old range {old_range} or new range {new_range} is too small for a floored result to be accurate.'
+        super().__init__(self.message)
+
+class UnexpectedNegativeNum(Exception):
+    def __init__(self):
+        self.message = f''
+        super().__init__(self.message)

--- a/src/utils/globs.py
+++ b/src/utils/globs.py
@@ -4,8 +4,10 @@ Note: For some reason, can't do from src.utils.globs import IMAGE_LIST in GUI/ma
 
 Idk why. But import src.utils.globs as globs works fine."""
 
-from src.utils.mri_image import MRIImageList
 import pathlib
+import warnings
+import functools
+from src.utils.mri_image import MRIImageList
 
 IMAGE_LIST: MRIImageList = MRIImageList()
 
@@ -17,3 +19,21 @@ IMG_DIR: pathlib.Path = pathlib.Path('.') / 'img'
 Files will need to be renamed during Add Image or Delete Image operations."""
 IMAGE_EXTENSION: str = 'jpg'
 """Extension for images stored in `IMG_DIR`."""
+
+
+# Source: https://stackoverflow.com/questions/2536307/decorators-in-the-python-standard-lib-deprecated-specifically
+def deprecated(func):
+    """This is a decorator which can be used to mark functions
+    as deprecated. It will result in a warning being emitted
+    when the function is used."""
+
+    @functools.wraps(func)
+    def new_func(*args, **kwargs):
+        warnings.simplefilter('always', DeprecationWarning)  # turn off filter
+        warnings.warn("Call to deprecated function {}.".format(func.__name__),
+                      category=DeprecationWarning,
+                      stacklevel=2)
+        warnings.simplefilter('default', DeprecationWarning)  # reset filter
+        return func(*args, **kwargs)
+
+    return new_func

--- a/tests/test_imgproc.py
+++ b/tests/test_imgproc.py
@@ -6,27 +6,42 @@ import SimpleITK as sitk
 import numpy as np
 import cv2
 import pytest
-import Playground.imgproc.imgproc_helpers as imgproc_helpers
-import Playground.imgproc.exceptions as exceptions
+import pathlib
+import src.utils.imgproc as imgproc
+import src.utils.exceptions as exceptions
 
-OUTPUT_DIR = 'out'
-NRRD1_PATH = 'ExampleData/BCP_Dataset_2month_T1w.nrrd'
-NRRD2_PATH = 'ExampleData/IBIS_Dataset_12month_T1w.nrrd'
-NRRD3_PATH = 'ExampleData/IBIS_Dataset_NotAligned_6month_T1w.nrrd'
-NIFTI_PATH = 'ExampleData/MicroBiome_1month_T1w.nii.gz'
+OUTPUT_DIR = pathlib.Path('out')
+NRRD1_PATH = pathlib.Path('ExampleData') / 'BCP_Dataset_2month_T1w.nrrd'
+NRRD2_PATH = pathlib.Path('ExampleData') / 'IBIS_Dataset_12month_T1w.nrrd'
+NRRD3_PATH = pathlib.Path('ExampleData') / 'IBIS_Dataset_NotAligned_6month_T1w.nrrd'
+NIFTI_PATH = pathlib.Path('ExampleData') / 'MicroBiome_1month_T1w.nii.gz'
 IMAGE_PATHS = [NRRD1_PATH, NRRD2_PATH, NRRD3_PATH, NIFTI_PATH]
 """For iterating over all images."""
 EPSILON = 0.001
 """Used for `float` comparisons."""
 
 reader = sitk.ImageFileReader()
-reader.SetFileName(NIFTI_PATH)
+# Choose a single MRI image to run tests on.
+reader.SetFileName(str(NIFTI_PATH))
 IMAGE_DONT_MUTATE = reader.Execute()
 """Reuse this image for tests; DO NOT MUTATE."""
 
+def test_all_images_min_value_0_max_value_less_than_1600():
+    types = ('*.nii.gz', '*.nii', '*.nrrd')
+    base_path = pathlib.Path('ExampleData')
+    reader = sitk.ImageFileReader()
 
-@pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
-def test_dimensions_of_np_array_same_as_original_image():
+    for type in types:
+        path_list = pathlib.Path(base_path).glob(type)
+        for img_path in path_list:
+            reader.SetFileName(str(img_path))
+            img: sitk.Image = reader.Execute()
+            img_np: np.ndarray = sitk.GetArrayFromImage(img)
+            assert img_np.min() == 0 and img_np.max() < 1600
+
+
+# @pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
+def test_dimensions_of_np_array_same_as_original_image_but_transposed():
     """Probably not needed but just in case.
     
     The dimensions of the numpy array are the same as the original image.
@@ -36,7 +51,7 @@ def test_dimensions_of_np_array_same_as_original_image():
     Pretty sure that means the arc length generated from the numpy array is the arc length of the original image, with the same units as the original image."""
     for image_path in IMAGE_PATHS:
         reader = sitk.ImageFileReader()
-        reader.SetFileName(image_path)
+        reader.SetFileName(str(image_path))
         image = reader.Execute()
         for slice_z in range(image.GetSize()[2]):
             slice = image[:, :, slice_z]
@@ -47,7 +62,22 @@ def test_dimensions_of_np_array_same_as_original_image():
             assert slice.GetSize()[1] == np_slice.shape[0]
 
 
-@pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
+# @pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
+def test_numpy_2D_slice_array_is_transpose_of_sitk_2D_slice_array():
+    """Confirm that the numpy matrix representation of a 2D slice is the transpose of the sitk matrix representation of a slice.
+
+    Can ignore this test later."""
+    for z_slice in range(10):
+        sitk_contour: sitk.Image = imgproc.rotate_and_get_contour(
+            IMAGE_DONT_MUTATE, 0, 0, 0, z_slice)
+        numpy_contour: np.ndarray = sitk.GetArrayFromImage(sitk_contour)
+
+        for i in range(len(numpy_contour)):
+            for j in range(len(numpy_contour[0])):
+                assert numpy_contour[i][j] == sitk_contour.GetPixel(j, i)
+
+
+# @pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
 def test_arc_length_works_same_on_binary_0_1_slice_and_binary_0_255_slice():
     """Test that cv2.arclength returns the same numbers for a file with 0's and 1's and a file with 0's and 255's.
 
@@ -60,12 +90,12 @@ def test_arc_length_works_same_on_binary_0_1_slice_and_binary_0_255_slice():
         for theta_y in range(2):
             for theta_z in range(2):
                 for slice_z in range(2):
-                    binary_contour = imgproc_helpers.rotate_and_get_contour(
+                    binary_contour = imgproc.rotate_and_get_contour(
                         IMAGE_DONT_MUTATE, theta_x, theta_y, theta_z, slice_z)
-                    circumference_1 = imgproc_helpers.get_contour_length(
+                    circumference_1 = imgproc.get_contour_length(
                         binary_contour)
 
-                    contour_255 = imgproc_helpers.rotate_and_get_contour(
+                    contour_255 = imgproc.rotate_and_get_contour(
                         IMAGE_DONT_MUTATE, theta_x, theta_y, theta_z, slice_z)
                     array_255: np.ndarray = sitk.GetArrayFromImage(contour_255)
                     for i in range(len(array_255)):
@@ -80,11 +110,11 @@ def test_arc_length_works_same_on_binary_0_1_slice_and_binary_0_255_slice():
                     assert circumference_1 == circumference_2
 
 
-@pytest.mark.skip(reason="Don't need this function")
+# @pytest.mark.skip(reason="Don't need this function")
 def test_our_arc_length_implementation_against_cv2_arc_length_implementation():
     """Test that our `arc_length` function works the same as cv2's."""
     for slice_z in range(0, 150, 15):
-        contour_slice = imgproc_helpers.rotate_and_get_contour(
+        contour_slice = imgproc.rotate_and_get_contour(
             IMAGE_DONT_MUTATE, 0, 0, 0, slice_z)
         # NOTE: np_contour_slice is the transpose of the sitk representation.
         # But don't need to worry about that for this test.
@@ -94,26 +124,11 @@ def test_our_arc_length_implementation_against_cv2_arc_length_implementation():
         contour = contours[0]
 
         cv2_arc_length = cv2.arcLength(contour, True)
-        our_arc_length = imgproc_helpers.arc_length(contour)
+        our_arc_length = imgproc.arc_length(contour)
         assert abs(cv2_arc_length - our_arc_length) < EPSILON
 
 
-@pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
-def test_numpy_2D_slice_array_is_transpose_of_sitk_2D_slice_array():
-    """Confirm that the numpy matrix representation of a 2D slice is the transpose of the sitk matrix representation of a slice.
-
-    Can ignore this test later."""
-    for z_slice in range(10):
-        sitk_contour: sitk.Image = imgproc_helpers.rotate_and_get_contour(
-            IMAGE_DONT_MUTATE, 0, 0, 0, z_slice)
-        numpy_contour: np.ndarray = sitk.GetArrayFromImage(sitk_contour)
-
-        for i in range(len(numpy_contour)):
-            for j in range(len(numpy_contour[0])):
-                assert numpy_contour[i][j] == sitk_contour.GetPixel(j, i)
-
-
-@pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
+# @pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
 def test_arc_length_of_transposed_matrix_is_same():
     """Per discussion here https://github.com/COMP523TeamD/HeadCircumferenceTool/commit/a230a6b57dc34ec433e311d760cc53841ddd6a49,
 
@@ -129,42 +144,42 @@ def test_arc_length_of_transposed_matrix_is_same():
     
     TODO: Unit test with pre-computed circumferences to really confirm this."""
     # Write settings of slices with more than 5 contours to a file to make sure they actually are just noise and not brain slices.
-    f = open('tests/noise_vals.txt', 'w')
+    f = open(pathlib.Path('tests') / 'noise_vals.txt', 'w')
     f.write('From test_arc_length_of_transposed_matrix_is_same\n')
 
     for theta_x in range(0, 90, 45):
         for theta_y in range(0, 90, 45):
             for theta_z in range(0, 90, 45):
                 for slice_z in range(0, 150, 15):
-                    sitk_contour: sitk.Image = imgproc_helpers.rotate_and_get_contour(IMAGE_DONT_MUTATE, theta_x, theta_y, theta_z, slice_z)
+                    sitk_contour: sitk.Image = imgproc.rotate_and_get_contour(IMAGE_DONT_MUTATE, theta_x, theta_y, theta_z, slice_z)
                     np_contour_non_transposed = np.ndarray.transpose(sitk.GetArrayFromImage(sitk_contour))
 
                     assert (sitk_contour.GetSize()[0] == np_contour_non_transposed.shape[0]) and (sitk_contour.GetSize()[1] == np_contour_non_transposed.shape[1])
 
                     try:
                         # get_contour_length will call sitk.GetArrayFromImage on the sitk.Image, returning a transposed np.ndarray()
-                        length_of_transposed_contour = imgproc_helpers.get_contour_length(sitk_contour)
+                        length_of_transposed_contour = imgproc.get_contour_length(sitk_contour)
                         # But if passing in a np.ndarray, then it won't transpose it
-                        length_of_non_transposed_contour = imgproc_helpers.get_contour_length(np_contour_non_transposed)
+                        length_of_non_transposed_contour = imgproc.get_contour_length(np_contour_non_transposed)
 
                         assert length_of_transposed_contour == length_of_non_transposed_contour
 
-                    except exceptions.ComputeCircumferenceOfNoise:
+                    except exceptions.ComputeCircumferenceOfInvalidSlice:
                         f.write(f'{theta_x, theta_y, theta_z, slice_z}\n')
     f.close()
 
 
-@pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
+# @pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
 def test_arc_length_of_transposed_matrix_is_same_hardcoded():
     """Same as above test but no rotations. Checks that the matrices are actually transposed.
     
     Tests all slices but ignores the result when there are more than 4 contours (usually occurs for very large slice value), which indicates that slice isn't a brain slice and looks like NIFTI slice 162."""
     # Write settings of slices with more than 5 contours to a file to make sure they actually are just noise and not brain slices.
-    f = open('tests/noise_vals.txt', 'a')
+    f = open(pathlib.Path('tests') / 'noise_vals.txt', 'a')
     f.write('From test_arc_length_of_transposed_matrix_is_same_hardcoded\n')
 
     for slice_z in range(0, IMAGE_DONT_MUTATE.GetSize()[2]):
-        sitk_contour: sitk.Image = imgproc_helpers.rotate_and_get_contour(IMAGE_DONT_MUTATE, 0, 0, 0, slice_z)
+        sitk_contour: sitk.Image = imgproc.rotate_and_get_contour(IMAGE_DONT_MUTATE, 0, 0, 0, slice_z)
         np_contour_transposed = sitk.GetArrayFromImage(sitk_contour)
         np_contour_not_transposed = np.ndarray.transpose(np_contour_transposed)
 
@@ -184,7 +199,7 @@ def test_arc_length_of_transposed_matrix_is_same_hardcoded():
     f.close()
 
 
-@pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
+# @pytest.mark.skip(reason="Passed in commit 6ebf428. Doesn't need to run again.")
 def test_contours_0_is_always_parent_contour_if_no_islands():
     """Assuming there are no islands in the image, then contours[0] results in the parent contour.
     
@@ -192,17 +207,32 @@ def test_contours_0_is_always_parent_contour_if_no_islands():
     hierarchy[0][i][3] is information about the parent contour of the i'th contour. So if hierarchy[0][0][3] = -1, then the 0'th contour is the parent."""
     for slice_z in range(IMAGE_DONT_MUTATE.GetSize()[2]):
         # rotate_and_get_contour removes islands
-        sitk_contour: sitk.Image = imgproc_helpers.rotate_and_get_contour(IMAGE_DONT_MUTATE, 0, 0, 0, slice_z)
+        sitk_contour: sitk.Image = imgproc.rotate_and_get_contour(IMAGE_DONT_MUTATE, 0, 0, 0, slice_z)
         contours, hierarchy = cv2.findContours(sitk.GetArrayFromImage(sitk_contour), cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
         assert hierarchy[0][0][3] == -1
 
+    
+def test_scale_to_range():
+    old_val = 500
+    old_min = 0
+    old_max = 1000
+    new_min = 0
+    new_max = 65535
+    # Since the new range is 0 to 65535, difference of 1 is fine
+    # The function assumes new range is large
+    assert abs(imgproc.scale_to_range(old_val, old_min, old_max, new_min, new_max) - 32767) < 1
 
-@pytest.mark.skip(reason="This is trivial")
+
+def test_scale_unsigned_num_to_unsigned_range():
+    assert abs(imgproc.scale_unsigned_num_to_unsigned_range(500, 1000, 65535) - 32767) < 1
+
+
+# @pytest.mark.skip(reason="This is trivial")
 def test_distance_2d():
     """Really don't need to test this. Testing just in case."""
     x: np.ndarray = np.array([0, 0])
     y: np.ndarray = np.array([3, 4])
-    assert abs(imgproc_helpers.distance_2d(x, y) - 5.0) < EPSILON
+    assert abs(imgproc.distance_2d(x, y) - 5.0) < EPSILON
     y = np.ndarray([3, 4, 5])
     with pytest.raises(AssertionError):
-        imgproc_helpers.distance_2d(x, y)
+        imgproc.distance_2d(x, y)

--- a/tests/test_mri_image.py
+++ b/tests/test_mri_image.py
@@ -11,10 +11,10 @@ import pathlib
 import src.utils.exceptions as exceptions
 from src.utils.mri_image import MRIImage, MRIImageList
 
-NRRD0_PATH = pathlib.Path('ExampleData/BCP_Dataset_2month_T1w.nrrd')
-NRRD1_PATH = pathlib.Path('ExampleData/IBIS_Dataset_12month_T1w.nrrd')
-NRRD2_PATH = pathlib.Path('ExampleData/IBIS_Dataset_NotAligned_6month_T1w.nrrd')
-NIFTI_PATH = pathlib.Path('ExampleData/MicroBiome_1month_T1w.nii.gz')
+NRRD0_PATH = pathlib.Path('ExampleData') / 'BCP_Dataset_2month_T1w.nrrd'
+NRRD1_PATH = pathlib.Path('ExampleData') / 'IBIS_Dataset_12month_T1w.nrrd'
+NRRD2_PATH = pathlib.Path('ExampleData') / 'IBIS_Dataset_NotAligned_6month_T1w.nrrd'
+NIFTI_PATH = pathlib.Path('ExampleData') / 'MicroBiome_1month_T1w.nii.gz'
 
 IMAGE_0 = MRIImage(NRRD0_PATH, 0, 0, 0, 0)
 IMAGE_1 = MRIImage(NRRD1_PATH, 3, 2, 1, 0)


### PR DESCRIPTION
https://youtu.be/GE80cbHEBy8

`np` array only is slightly faster. Both approaches are slow on [image 6](https://github.com/COMP523TeamD/HeadCircumferenceTool/blob/main/ExampleData/IBIS_Dataset_NotAligned_6month_T1w.nrrd).

`np` array only performance starts at [0:46](https://youtu.be/GE80cbHEBy8?t=46).