### PR TITLE
Fix #42, show app icon in Windows dock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: ui_mainwindow.py|stylesheet.qss|resources.py
+exclude: ui_mainwindow.py|stylesheet.qss|resources.py|gui|gui.pyw
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ This will be run automatically before each commit.
 
 ## Modify pre-commit git hook
 
-Edit `.pre-commit-config.yaml`.
+Edit [`.pre-commit-config.yaml`](.pre-commit-config.yaml).
 
-`pre-commit install`
+Then run `pre-commit install`.
 
 More instructions [here](https://pre-commit.com).
+
+Do not name any source code files `ui_mainwindow.py|stylesheet.qss|resources.py|gui|gui.pyw`.
+These files are ignored in [`.pre-commit-config.yaml`](.pre-commit-config.yaml).

--- a/config.json
+++ b/config.json
@@ -19,7 +19,7 @@
     "CONTOUR_COLOR": "",
     // Startup width and height of the GUI as a ratio of primary monitor size.
     // Enter a number between 0 (not inclusive) and 1.
-    "STARTUP_WIDTH_RATIO": 0.65,
-    "STARTUP_HEIGHT_RATIO": 0.6,
+    "STARTUP_WIDTH_RATIO": 0.75,
+    "STARTUP_HEIGHT_RATIO": 0.7,
     "DISPLAY_ADVANCED_MENU_MESSAGES_IN_TERMINAL": "False"
 }

--- a/config.json
+++ b/config.json
@@ -19,7 +19,7 @@
     "CONTOUR_COLOR": "",
     // Startup width and height of the GUI as a ratio of primary monitor size.
     // Enter a number between 0 (not inclusive) and 1.
-    "STARTUP_WIDTH_RATIO": 0.75,
-    "STARTUP_HEIGHT_RATIO": 0.7,
+    "STARTUP_WIDTH_RATIO": 0.65,
+    "STARTUP_HEIGHT_RATIO": 0.6,
     "DISPLAY_ADVANCED_MENU_MESSAGES_IN_TERMINAL": "False"
 }

--- a/gui.py
+++ b/gui.py
@@ -4,9 +4,39 @@
 # This file is meant to be run from the terminal via ./gui.py.
 # Windows users can also double-click it, but a terminal would pop up
 
+import sys
+import os
+
+# Source: https://stackoverflow.com/questions/5047734/in-osx-change-application-name-from-python
+if sys.platform.startswith("darwin"):
+    # Set app name, if PyObjC is installed
+    # Python 2 has PyObjC preinstalled
+    # Python 3: pip3 install pyobjc-framework-Cocoa
+    try:
+        from Foundation import NSBundle
+
+        bundle = NSBundle.mainBundle()
+        if bundle:
+            app_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+            app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+            if app_info:
+                app_info["CFBundleName"] = app_name
+    except ImportError:
+        pass
+
+# Source: https://stackoverflow.com/questions/1551605/how-to-set-applications-taskbar-icon-in-windows-7/1552105#1552105
+# myappid: Use unicode
+import ctypes
+
+myappid = u"mycompany.myproduct.subproduct.version"  # arbitrary string
+try:
+    # For Windows. App icon works without this on macOS.
+    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
+except:
+    pass
+
 from src.GUI.main import main
 from src.utils.parser import parse_json, parse_gui_cli
-
 parse_json()
 parse_gui_cli()
 main()

--- a/gui.pyw
+++ b/gui.pyw
@@ -1,11 +1,41 @@
 #!/usr/bin/env python3
 
-# Note: If changing this file, mirror the changes into gui.pyw
-# This file can be double-clicked on Windows to start without opening a terminal
+# Note: If changing this file, mirror the changes into gui.py
+# Windows users should be able to double-click this file to run it without a terminal popping up
+# Currently doesn't work, though
+
+import sys
+import os
+
+# Source: https://stackoverflow.com/questions/5047734/in-osx-change-application-name-from-python
+if sys.platform.startswith("darwin"):
+    # Set app name, if PyObjC is installed
+    # Python 2 has PyObjC preinstalled
+    # Python 3: pip3 install pyobjc-framework-Cocoa
+    try:
+        from Foundation import NSBundle
+
+        bundle = NSBundle.mainBundle()
+        if bundle:
+            app_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+            app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+            if app_info:
+                app_info["CFBundleName"] = app_name
+    except ImportError:
+        pass
+
+# Source: https://stackoverflow.com/questions/1551605/how-to-set-applications-taskbar-icon-in-windows-7/1552105#1552105
+import ctypes
+
+myappid = u"mycompany.myproduct.subproduct.version"  # arbitrary string
+try:
+    # For Windows. App icon works without this on macOS.
+    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(myappid)
+except:
+    pass
 
 from src.GUI.main import main
 from src.utils.parser import parse_json, parse_gui_cli
-
 parse_json()
 parse_gui_cli()
 main()

--- a/src/GUI/main.py
+++ b/src/GUI/main.py
@@ -885,7 +885,10 @@ def main() -> None:
 
     MAIN_WINDOW = MainWindow()
 
-    MAIN_WINDOW.setMinimumSize(QSize(0, 0))
+    # Non-zero min width and height is needed to prevent
+    # this bug https://github.com/COMP523TeamD/HeadCircumferenceTool/issues/42
+    # However, this also seems to affect startup GUI size or at least GUI element spacing
+    MAIN_WINDOW.setMinimumSize(QSize(1, 1))
     MAIN_WINDOW.resize(
         int(
             user_settings.STARTUP_WIDTH_RATIO * constants.PRIMARY_MONITOR_DIMENSIONS[0]

--- a/src/GUI/main.py
+++ b/src/GUI/main.py
@@ -181,6 +181,7 @@ class MainWindow(QMainWindow):
             widget.setEnabled(True)
 
         self.action_export_csv.setEnabled(not SETTINGS_VIEW_ENABLED)
+        self.export_button.setEnabled(not SETTINGS_VIEW_ENABLED)
         self.disable_binary_threshold_inputs()
 
     def enable_binary_threshold_inputs(self) -> None:

--- a/src/GUI/main.py
+++ b/src/GUI/main.py
@@ -35,7 +35,7 @@ from PyQt6.QtWidgets import (
     QMessageBox,
 )
 from PyQt6.uic.load_ui import loadUi
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QSize
 
 import pprint
 from src.utils.constants import View, ThresholdFilter
@@ -116,9 +116,6 @@ class MainWindow(QMainWindow):
         loadUi(str(PATH_TO_UI_FILE), self)
 
         self.setWindowTitle("Head Circumference Tool")
-
-        # TODO: Remove if not needed (since main() now has a line that does this)
-        # self.setWindowIcon(QIcon(str(PATH_TO_HCT_LOGO)))
 
         self.action_open.triggered.connect(lambda: self.browse_files(False))
         self.action_add_images.triggered.connect(lambda: self.browse_files(True))
@@ -860,13 +857,17 @@ def main() -> None:
     """Main entrypoint of GUI."""
     # This import can't go at the top of the file
     # because gui.py.parse_gui_cli() has to set THEME_NAME before the import occurs
+    # This imports globally
+    # For example, src/GUI/helpers.py can access resource files without having to import there
     importlib.import_module(f"src.GUI.themes.{user_settings.THEME_NAME}.resources")
 
     if not user_settings.IMG_DIR.exists():
         user_settings.IMG_DIR.mkdir()
 
     app = QApplication(sys.argv)
-    # On macOS (maybe Windows too, idk), sets the application logo in the dock
+
+    # On macOS, sets the application logo in the dock (but no window icon on macOS)
+    # On Windows, sets the window icon at the top left of the window (but no dock icon on Eric's Windows computer)
     app.setWindowIcon(QIcon(str(PATH_TO_HCT_LOGO)))
 
     # TODO: Put arrow buttons on the left and right endpoints of the sliders
@@ -884,6 +885,7 @@ def main() -> None:
 
     MAIN_WINDOW = MainWindow()
 
+    MAIN_WINDOW.setMinimumSize(QSize(0, 0))
     MAIN_WINDOW.resize(
         int(
             user_settings.STARTUP_WIDTH_RATIO * constants.PRIMARY_MONITOR_DIMENSIONS[0]

--- a/src/GUI/mainwindow.ui
+++ b/src/GUI/mainwindow.ui
@@ -45,22 +45,6 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer_10">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>10</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -604,22 +588,6 @@
              </layout>
             </item>
             <item>
-             <spacer name="verticalSpacer_9">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>10</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
              <widget class="QPushButton" name="smoothing_preview_button">
               <property name="enabled">
                <bool>false</bool>
@@ -847,22 +815,6 @@
              </layout>
             </item>
             <item>
-             <spacer name="verticalSpacer_14">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::MinimumExpanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
              <widget class="QPushButton" name="threshold_preview_button">
               <property name="enabled">
                <bool>false</bool>
@@ -877,22 +829,6 @@
          </layout>
         </item>
        </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_20">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
       <item>
        <widget class="QPushButton" name="apply_button">


### PR DESCRIPTION
Also changed `gui.py` to `gui`. You would now run with `./gui` (macOS/Linux) or `python gui` (a bit weird, but saw this might help with showing an app name in the macOS dock?).