### PR TITLE
Revert mainwindow.ui changes in 9e38129, keep 5e438d5

### DIFF
--- a/src/GUI/mainwindow.ui
+++ b/src/GUI/mainwindow.ui
@@ -45,6 +45,22 @@
        </widget>
       </item>
       <item>
+       <spacer name="verticalSpacer_10">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -588,6 +604,22 @@
              </layout>
             </item>
             <item>
+             <spacer name="verticalSpacer_9">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::MinimumExpanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QPushButton" name="smoothing_preview_button">
               <property name="enabled">
                <bool>false</bool>
@@ -815,6 +847,22 @@
              </layout>
             </item>
             <item>
+             <spacer name="verticalSpacer_14">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::MinimumExpanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QPushButton" name="threshold_preview_button">
               <property name="enabled">
                <bool>false</bool>
@@ -829,6 +877,22 @@
          </layout>
         </item>
        </layout>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_20">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item>
        <widget class="QPushButton" name="apply_button">
@@ -1077,7 +1141,7 @@
     <addaction name="action_print_direction"/>
     <addaction name="action_print_spacing"/>
    </widget>
-   <widget class="QMenu" name="menuView">
+   <widget class="QMenu" name="menu_view">
     <property name="title">
      <string>View</string>
     </property>
@@ -1085,7 +1149,7 @@
    </widget>
    <addaction name="menu_file"/>
    <addaction name="menu_help"/>
-   <addaction name="menuView"/>
+   <addaction name="menu_view"/>
    <addaction name="menu_debug"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
@@ -1384,7 +1448,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="view_button_group"/>
   <buttongroup name="threshold_button_group"/>
+  <buttongroup name="view_button_group"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
This somewhat breaks initial spacing on macOS but makes GUI look better when resizing.

Overall, the spacers should definitely be kept and we should update initial sizing without removing the spacers.